### PR TITLE
Fix OS detection in pixel utilities

### DIFF
--- a/pixel/utils.py
+++ b/pixel/utils.py
@@ -1,12 +1,10 @@
 from math import sqrt
+import sys
 import numpy as np
 import pyautogui
 from time import sleep
 
-try:
-    from scapy.consts import WINDOWS
-except:
-    WINDOWS = True
+WINDOWS = sys.platform.startswith("win")
 
 if WINDOWS:
     PYGUI_RES = (1, 1)


### PR DESCRIPTION
## Summary
- simplify Windows detection logic for pixel automation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68470ba7b04c832b823aefb061df9c88